### PR TITLE
Switch comments provider from Utterances to Disqus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,15 +46,12 @@ author:
       icon: "fab fa-twitter"
       url: "https://x.com/dzenyu"
 
-# Comments provider (Utterances)
+# Comments provider (disqus)
 repository: "dzenyu/dzenyu.github.io"
 comments:
-  provider: "utterances"
-  utterances:
-    repo: "dzenyu/dzenyu.github.io"
-    issue_term: "pathname"
-    label: "💬 comment"
-    theme: "github-light"
+  provider: "disqus"
+  disqus:
+    shortname: "dzenyu"  # <-- replace with your Disqus shortname
 
 # Front matter defaults
 defaults:


### PR DESCRIPTION
Updated the _config.yml to use Disqus as the comments provider instead of Utterances. Disqus configuration with the appropriate shortname has been added, and Utterances-specific settings have been removed.