### PR TITLE
Update site theme, navigation, and about page content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ remote_theme: "mmistakes/minimal-mistakes@4.26.2"
 # Available skins you can try:
 #   default, air, aqua, contrast, dark, dirt, neon, mint, plum, sunrise
 # To test: change the value below, then `bundle exec jekyll serve` and refresh.
-minimal_mistakes_skin: "sunrise"
+minimal_mistakes_skin: "contrast"
 locale: "en-US"
 
 enable_copy_code_button: true
@@ -33,7 +33,7 @@ author:
   name   : "Dzenyu Mukangara"
 #  avatar : "/assets/images/avatar.jpg"
   avatar : "/assets/images/my-avatar.png"
-  bio    : "Principal Engineer, Engineering Leadership | Java, Spring, Kafka, AWS | Mentoring, Coaching, Micro Services"
+  bio    : "Principal Engineer, Engineering Leadership | Mentoring, Coaching, Micro Services, Cloud Computing, AI"
   location : "Dallas, USA"
   links:
     - label: "GitHub"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,10 +3,10 @@ main:
     url: /
   - title: "Blog"
     url: /blog/
-  - title: "Tags"
-    url: /tags/
   - title: "Categories"
     url: /categories/
+  - title: "Tags"
+    url: /tags/
   - title: "Search"
     url: /search/
   - title: "About"

--- a/about.md
+++ b/about.md
@@ -3,15 +3,16 @@ layout: single
 title: "About"
 permalink: /about/
 author_profile: true
+read_time: true
+share: true
+toc: true
+toc_sticky: true
+description: "Principal Engineer specializing in Java, Spring, Kafka, AWS, and building resilient, high-throughput systems."
 ---
 
-Hi, I’m **Dzenyu Mukangara** — a Principal Engineer passionate about building resilient systems, scaling distributed architectures, and mentoring the next generation of engineers. I specialize in **Java, Spring, Kafka, AWS, and cloud-native engineering**, and I enjoy bringing clarity and simplicity to complex technical challenges.
+Hi, I’m Dzenyu Mukangara — a Principal Engineer who enjoys turning complex requirements into simple, maintainable systems. I work across architecture, hands-on coding, and engineering leadership to help teams ship reliable software at scale.
 
-This blog is where I share **architecture lessons, deep dives into distributed systems, and leadership insights** from my years of building high-scale platforms.
-
----
-
-### A Little About Me
+## A Little About Me
 
 Beyond the world of tech, I’m a husband and proud dad of two amazing kids. Family is at the heart of everything I do — whether it’s cheering on my kids’ adventures, enjoying movie nights, or exploring the world together.
 
@@ -19,44 +20,49 @@ Travel is one of our favorite ways to connect as a family. We’ve created lasti
 
 When I’m not building systems or spending time with my family, you’ll often find me listening to music. My playlists are usually a mix of **Afrobeat, Gospel, RnB, Sungura, and Reggae** — music that keeps me energized, inspired, and grounded.
 
----
+## What I do
+- Architecture and delivery for data-intensive services (batch + streaming)
+- Java/Spring microservices with pragmatic DevOps on AWS
+- Event-driven design with Kafka (streams, schema, state stores)
+- System hardening: observability, reliability, and cost-aware scaling
+- Mentoring and building high-performing engineering teams
 
-### Key Areas of Expertise
+## Current focus
+- Stream processing patterns with Kafka Streams and RocksDB performance tuning
+- Event-sourcing and transactional outbox for consistency
+- Cloud cost guardrails (right-sizing, autoscaling, data layout)
+- Developer experience: golden paths, templates, and code quality tooling
 
-- **Database Tooling**  
-  Built enterprise-grade solutions simplifying database management across platforms. Contributed to tools at Embarcadero Technologies (now Idera) used by professionals worldwide.
+## Highlights
+- Database tooling: Delivered cross-platform admin utilities used by DBAs worldwide (Embarcadero/Idera).
+- Media metadata distribution: Built large-scale playlist and EPG pipelines (TiVo Corp.).
+- Hybrid AWS: Led migrations and built fault-tolerant services across on‑prem and AWS (S3, EC2, DynamoDB, ElastiCache).
+- Payments and subscriptions: Integrated Braintree, Stripe, Recurly, BillDesk (UPI), and in‑app purchase workflows.
+- Batch and data pipelines: Spring Batch, AWS Batch, AWS DMS for resilient movement and transformation.
 
-- **Media Metadata Distribution**  
-  Engineered large-scale playlist creation and monitoring systems powering workflows for leading media companies.
+## Speaking & writing
+- I share practical notes on architecture, Java/Spring practices, and platform thinking.
+- Popular topics: testing strategies, migration playbooks, and production debugging.
+- Explore by taxonomy:
+  - Tags: /tags/
+  - Categories: /categories/
 
-- **Electronic Program Guide (EPG) Management**  
-  Designed and managed metadata distribution systems for **TiVo Corp.**, ensuring seamless integration and delivery.
+## Tech stack (abridged)
+- Languages/Frameworks: Java, Spring Boot, Spring Cloud, GraphQL, REST
+- Data/Streaming: Kafka, Kafka Streams, Kinesis, DynamoDB, Redis, MySQL/Postgres
+- Cloud/Platform: AWS (CloudFormation, ECS, Lambda, Step Functions), Docker, Nginx
+- Build/Quality: Gradle/Maven, JUnit 5, Testcontainers, AssertJ, Spotless, Checkstyle
+- Observability: CloudWatch, OpenTelemetry, Grafana (as applicable)
 
-- **Cloud Infrastructure (AWS)**  
-  Deep expertise in AWS, managing complex hybrid deployments across on-prem and cloud. Proficient in:
-    - S3, EC2, DynamoDB, ElastiCache
-    - CloudFormation, Elastic Beanstalk, ECS
-    - Kinesis, Lambda, Step Functions
-    - CloudWatch, AWS MSK (Kafka)
+## How I work
+- Bias for clarity: simple designs, small PRs, and production-first thinking
+- Pragmatic quality: tests that matter, guardrails over gatekeeping
+- Operational empathy: logs/metrics/traces by default; SLOs guide design
+- Collaborative leadership: unblock fast, mentor often, write it down
 
-- **Enterprise Application Development**  
-  Expert in Java Enterprise and Spring-based deployments. Skilled in Docker, Nginx, and Node.js for resilient and scalable apps.
+## Mentorship
+I enjoy coaching engineers on system design, testing, and platform fundamentals. If you’re looking to level up a team or bootstrap a new service safely, I’m happy to help.
 
-- **Batch Processing & Data Pipelines**  
-  Designed workflows using **Spring Batch**, **AWS Batch**, and **AWS DMS** to support robust data processing pipelines.
+## Contact
 
-- **REST & GraphQL Web Services**  
-  Built scalable APIs with REST and GraphQL for high performance and developer experience.
-
-- **Databases & Data Insights**  
-  Hands-on with Oracle, SQL Server, MySQL, MongoDB, DynamoDB, Neo4j, and dGraph. Enthusiastic about uncovering graph-based relationships for deeper insights.
-
-- **Payments & Subscriptions**  
-  Integrated with gateways like Braintree, Stripe, Recurly, and BillDesk (UPI).
-
-- **Mentorship & Leadership**  
-  Passionate about mentoring engineers, driving technical excellence, and leading teams to deliver impactful systems.
-
----
-
-Thanks for stopping by my corner of the internet. If you enjoy geeking out on distributed systems, cloud infrastructure, or engineering leadership, you’ll feel right at home here.
+If you have a problem that involves data, scale, or reliability—and needs a clear path to production—let’s talk. Find me on LinkedIn.


### PR DESCRIPTION
Changed the Minimal Mistakes skin from 'sunrise' to 'contrast' for a new look. Updated author bio to emphasize mentoring, microservices, cloud, and AI. Reordered navigation to place 'Categories' before 'Tags'. Significantly revised the about page with a new structure, updated expertise, current focus, and contact information, providing a clearer overview of skills and areas of interest.